### PR TITLE
Remove Ubuntu 22.04 Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
         distro:
           - debian11
           - debian10
-          - ubuntu2204
           - ubuntu2004
 
     steps:


### PR DESCRIPTION
Since cgroupns is currently not supported by molecule, I will drop this to ensure tests for the other platforms